### PR TITLE
Speed up /api/v3/jobs: replace ROW_NUMBER() first-volume subquery with MIN(JobMediaId) join

### DIFF
--- a/API/Modules/JobManager.php
+++ b/API/Modules/JobManager.php
@@ -92,15 +92,15 @@ COALESCE(mi.volcount, 0) AS volcount,
 ' . $add_cols . '
 FROM Job 
 LEFT JOIN (
-	SELECT
-		JobMedia.JobId AS jobid,
-		Media.VolumeName AS volumename,
-		ROW_NUMBER() OVER (PARTITION BY JobMedia.JobId ORDER BY JobMedia.JobMediaId) AS jmi
-	FROM
-		Media
-	LEFT JOIN
-		JobMedia USING (MediaId)
-) AS jm ON jm.JobId=Job.JobId AND jm.jmi=1 
+  SELECT jm.JobId AS jobid, m.VolumeName AS volumename
+  FROM JobMedia jm
+  JOIN (
+    SELECT JobId, MIN(JobMediaId) AS min_jmid
+    FROM JobMedia
+    GROUP BY JobId
+  ) first ON first.JobId = jm.JobId AND first.min_jmid = jm.JobMediaId
+  JOIN Media m ON m.MediaId = jm.MediaId
+) AS jm ON jm.jobid = Job.JobId
 LEFT JOIN (
 	SELECT
 		JobMedia.JobId AS jobid,


### PR DESCRIPTION
Hello @ganiuszka ,

This PR optimizes the “first volume” join used by `/api/v3/jobs`.
We replace the window function:
```sql
ROW_NUMBER() OVER (PARTITION BY JobMedia.JobId ORDER BY JobMedia.JobMediaId)
```
with a cheaper, cross-DB join that uses:
```sql
MIN(JobMediaId) per JobId
```
This keeps the result identical (first volume per job) while avoiding a full scan/ranking over `JobMedia`.
**Why**
On a Debian 12 + MariaDB 10.11 catalog with \~1.2M `JobMedia` rows, the original query took \~35s for a 7-day window due to the window function.
With this change, the same request completes in **\~0.46s**.
**Environment / Benchmarks**
* Bacula Community 15.0.2, Bacularis 5.0, MariaDB 10.11
* `/api/v3/jobs?director=<dir>&age=604800&limit=500`
  * **Before:** \~35 s
  * **After:** **\~0.46 s**
* Also tested on PostgreSQL (small env: \~6k jobs / \~2k volumes) — works fine.
**Patch (SQL fragment)**
```sql
-- BEFORE
LEFT JOIN (
  SELECT JobMedia.JobId AS jobid,
         Media.VolumeName AS volumename,
         ROW_NUMBER() OVER (PARTITION BY JobMedia.JobId ORDER BY JobMedia.JobMediaId) AS jmi
  FROM Media
  LEFT JOIN JobMedia USING (MediaId)
) AS jm ON jm.JobId = Job.JobId AND jm.jmi = 1
-- AFTER
LEFT JOIN (
  SELECT jm.JobId AS jobid, m.VolumeName AS volumename
  FROM JobMedia jm
  JOIN (
    SELECT JobId, MIN(JobMediaId) AS min_jmid
    FROM JobMedia
    GROUP BY JobId
  ) first ON first.JobId = jm.JobId AND first.min_jmid = jm.JobMediaId
  JOIN Media m ON m.MediaId = jm.MediaId
) AS jm ON jm.jobid = Job.JobId
```
**Notes**
* No behavior change in the API output.
* This is SQL-standard and works across MariaDB/MySQL and PostgreSQL.
* Optional DBA tip (out of scope for code): indexes that helped in large catalogs:
  * `Job(StartTime, JobId)` and `Job(StartTime, Name)`
  * `JobMedia(JobId, JobMediaId, MediaId)`

Thanks for the review! Happy to adjust the patch if you prefer a different SQL style or want this behind a DB-dialect switch.
